### PR TITLE
style: minor adjustments

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { render } from 'react-dom';
 import injectTapEventPlugin from 'react-tap-event-plugin';
-import List from '../dist/components/list/index.js';
+import moment from 'moment';
+import List from '../src/components/list/index.js';
 
 injectTapEventPlugin();
 //
@@ -10,7 +11,6 @@ injectTapEventPlugin();
 const hasNextPage = true;
 const hasPreviousPage = false;
 const paginationText = '1 - 15 of 300';
-const changeRowsPerPage = (...args) => console.log('changeRowsPerPage ran', ...args);
 const nextPage = (...args) => console.log('nextPage ran', ...args);
 const previousPage = (...args) => console.log('previousPage ran', ...args);
 const handleRouting = (...args) => console.log('handleRouting ran', ...args);
@@ -76,6 +76,13 @@ const columns = [
     sortable: true,
     filterable: true,
   },
+  {
+    label: 'Important Date',
+    key: 'date',
+    sortable: false,
+    filterable: false,
+    format: date => date.format('DD.MM.YYYY'),
+  },
 ];
 
 const items = [
@@ -83,41 +90,59 @@ const items = [
     firstName: 'ragnar',
     lastName: 'lodbrok',
     email: 'ragnar.lodbrok@gmail.com',
+    date: moment(),
   },
   {
     firstName: 'rachael',
     lastName: 'ray',
     email: 'rachael.ray@gmail.com',
+    date: moment(),
   },
   {
     firstName: 'guy',
     lastName: 'fieri',
     email: 'dinersdriveinsandlols@gmail.com',
     avatar: '',
+    date: moment(),
   },
 ];
 
-const Wrapper = () => (
-  <List
-    avatar={avatar}
-    tableName={tableName}
-    items={items}
-    columns={columns}
-    hasNextPage={hasNextPage}
-    hasPreviousPage={hasPreviousPage}
-    paginationText={paginationText}
-    changeRowsPerPage={changeRowsPerPage}
-    nextPage={nextPage}
-    previousPage={previousPage}
-    handleDelete={handleDelete}
-    listRowOnclick={listRowOnclick}
-    actions={actions}
-    handleFilter={handleFilter}
-    handleSort={handleSort}
-    handleSearch={handleSearch}
-    filters={filters}
-    sortOptions={sortOptions} />
-);
+class Wrapper extends Component {
+  state = {
+    rows: 15,
+  };
+
+  changeRowsPerPage = (rows) => {
+    this.setState({ rows });
+    console.log('changeRowsPerPage ran', rows);
+  };
+
+  render() {
+    return (
+      <List
+        avatar={avatar}
+        tableName={tableName}
+        items={items}
+        columns={columns}
+        hasNextPage={hasNextPage}
+        hasPreviousPage={hasPreviousPage}
+        paginationText={paginationText}
+        changeRowsPerPage={this.changeRowsPerPage}
+        nextPage={nextPage}
+        listRowOnclick={listRowOnclick}
+        previousPage={previousPage}
+        handleDelete={handleDelete}
+        actions={actions}
+        handleFilter={handleFilter}
+        handleSort={handleSort}
+        handleSearch={handleSearch}
+        filters={filters}
+        rows={this.state.rows}
+        containerStyle={{ padding: 96 }}
+        sortOptions={sortOptions} />
+    );
+  }
+}
 
 render(
   <Wrapper />,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mui-table",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A react component that takes data & style parameters, and renders a Material UI table.",
   "main": "dist/components/list/index.js",
   "scripts": {
@@ -49,7 +49,8 @@
     "file-loader": "^0.9.0",
     "html-webpack-plugin": "^2.24.1",
     "jest": "^17.0.3",
-    "material-ui": "^0.15.2",
+    "material-ui": "^0.15.4",
+    "moment": "^2.17.1",
     "react-addons-test-utils": "^15.4.1",
     "react-dom": "^15.3.0",
     "react-tap-event-plugin": "2.0.0",

--- a/src/components/list/ListColumns.js
+++ b/src/components/list/ListColumns.js
@@ -82,6 +82,7 @@ export default class ListColumns extends Component {
       <div style={styles.wrapper}>
         <Checkbox
           style={{ ...styles.checkbox, ...avatarStyles }}
+          checked={this.props.selectedAll}
           onCheck={handleSelectAll} />
         {columns.map(column =>
           <div

--- a/src/components/list/ListRow.js
+++ b/src/components/list/ListRow.js
@@ -40,6 +40,7 @@ export default class ListRow extends Component {
       column: {
         position: 'relative',
         top: -5,
+        wordWrap: 'break-word',
         display: 'inline-block',
         width: `calc(${Math.floor(100 / (columns.length + 1)).toString()}% - 1em)`,
       },
@@ -71,11 +72,15 @@ export default class ListRow extends Component {
         customSpacing = { paddingLeft: 5 };
       }
 
+      let columnValue = selectn(column.key, item);
+
+      if (columnValue && column.format) columnValue = column.format(columnValue);
+
       rowColumns.push(
         <div
           key={`${column.key}`}
           style={{ ...customSpacing, ...styles.column }}>
-          {selectn(column.key, item) || ''}
+          {columnValue || ''}
         </div>
       );
     });

--- a/src/components/list/index.js
+++ b/src/components/list/index.js
@@ -31,7 +31,6 @@ const styles = {
 
 export default class ReactMuiTable extends Component {
   state = {
-    numRows: 15,
     itemsSelected: [],
   };
 
@@ -88,13 +87,12 @@ export default class ReactMuiTable extends Component {
           handleSearch={this.props.handleSearch} />
       );
     }
-
+    
     return (
-      <div style={styles.containerWrapper}>
+      <div className={this.props.containerClass} style={this.props.containerStyle}>
         <MuiThemeProvider>
           <div>
             {optionalSearch}
-
             <Paper zDepth={2}>
               <List style={styles.listContentWrapper}>
                 <Masthead
@@ -131,7 +129,7 @@ export default class ReactMuiTable extends Component {
                   changeRowsPerPage={this.props.changeRowsPerPage}
                   nextPage={this.handleNextPage}
                   previousPage={this.handlePreviousPage}
-                  numRows={this.state.numRows} />
+                  rows={this.props.rows} />
               </List>
             </Paper>
           </div>

--- a/src/components/masthead/index.js
+++ b/src/components/masthead/index.js
@@ -11,6 +11,8 @@ const Masthead = ({ itemSelectedCount, handleDeletePointer, filters, handleFilte
         handleDeletePointer={handleDeletePointer} />
     );
   }
+  if (filters.length === 0) return null;
+
   return (
     <Filter
       filters={filters}

--- a/src/components/pagination/RowsPerPage.js
+++ b/src/components/pagination/RowsPerPage.js
@@ -32,6 +32,10 @@ class RowsPerPage extends Component {
     ],
   };
 
+  menuChangeHandler = (evt, key, value) => {
+    this.props.changeRowsPerPage(value);
+  }
+
   render() {
     return (
       <div style={styles.rowsPerPage}>
@@ -39,12 +43,12 @@ class RowsPerPage extends Component {
           Rows per page:
         </span>
         <DropDownMenu
-          value={this.props.numRows}
+          value={this.props.rows}
           labelStyle={styles.dropDownMenu}
+          onChange={this.menuChangeHandler}
           underlineStyle={styles.underlineStyle}>
           {this.state.rowOptions.map(opt =>
             <MenuItem
-              onClick={this.props.changeRowsPerPage.bind(null, opt)}
               key={opt}
               value={opt}
               primaryText={opt.toString()} />

--- a/src/components/pagination/index.js
+++ b/src/components/pagination/index.js
@@ -44,7 +44,7 @@ class Pagination extends Component {
     const {
       hasNextPage,
       hasPreviousPage,
-      numRows,
+      rows,
       paginationText,
       changeRowsPerPage,
      } = this.props;
@@ -56,7 +56,7 @@ class Pagination extends Component {
           <RowsPerPage
             paginationText={paginationText}
             changeRowsPerPage={changeRowsPerPage}
-            numRows={numRows} />
+            rows={rows} />
 
           <div style={styles.caretWrapper}>
             <IconButton

--- a/src/components/search/index.js
+++ b/src/components/search/index.js
@@ -18,7 +18,7 @@ const styles = {
     color: 'rgba(0, 0, 0, .54)',
     fontWeight: '400',
     fontSize: 14,
-    width: '95.5%',
+    width: 'calc(100% - 50px)',
   },
 };
 


### PR DESCRIPTION
### Issues resolved
* fixes #14 uses the already passed prop into the header column to control checked state
* Fixes #13 by not displaying the filter bar if there are no filters. 
* progresses #9 by breaking words to next line. Though ideally there is a better solution regarding column widths
* fixes #8 by using a prop passed from wrapper to set the number of rows instead of internal component state. 


### Changes
* adds a class and style prop to the root component to allow specifying padding/styles
* Uses calc css property to properly prevent search field and icon from breaking to two lines

### Discoveries
Our "ListItems" aren't really "ListItems" because we are doing:
```js
import ListItem from 'material-ui/list';
```
instead of 
```js
import { ListItem } from 'material-ui/list';
```

I tried a quick fix on this and it caused more issues than it solved so gonna leave it functional for now.