### PR TITLE
Feature/row actions

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -2,6 +2,10 @@ import React, { Component } from 'react';
 import { render } from 'react-dom';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 import moment from 'moment';
+import PublishIcon from 'material-ui/svg-icons/action/visibility';
+import UnpublishIcon from 'material-ui/svg-icons/action/visibility-off';
+import EditIcon from 'material-ui/svg-icons/editor/mode-edit';
+import DeleteIcon from 'material-ui/svg-icons/action/delete';
 import List from '../src/components/list/index.js';
 
 injectTapEventPlugin();
@@ -18,7 +22,6 @@ const handleDelete = id => console.log('handleDelete ran: ', id);
 const handleFilter = (...args) => console.log('handleFilter ran', ...args);
 const handleSort = (...args) => console.log(...args);
 const handleSearch = (...args) => console.log('handleSearch ran', ...args);
-const listRowOnclick = (...args) => console.log('listRowOnclick ran', ...args);
 
 //
 // Dummy data
@@ -32,12 +35,29 @@ const actions = [
     text: 'Delete',
     action: 'delete',
     handler: handleDelete,
-    icon: 'Trashcan',
-  }, {
+    enabled: true,
+    icon: <DeleteIcon />,
+  },
+  {
+    text: 'Publish',
+    action: 'publish',
+    handler: () => {console.log('publish ran');},
+    enabled: item => item.status !== 'unpublished',
+    icon: <PublishIcon />,
+  },
+  {
+    text: 'Unpublish',
+    action: 'unpublish',
+    handler: () => {console.log('unpublish ran');},
+    enabled: item => item.status !== 'published',
+    icon: <UnpublishIcon />,
+  },
+  {
     text: 'Edit',
     action: 'edit',
     handler: handleRouting,
-    icon: 'Edit',
+    enabled: true,
+    icon: <EditIcon />,
   },
 ];
 
@@ -90,18 +110,21 @@ const items = [
     firstName: 'ragnar',
     lastName: 'lodbrok',
     email: 'ragnar.lodbrok@gmail.com',
+    status: 'published',
     date: moment(),
   },
   {
     firstName: 'rachael',
     lastName: 'ray',
     email: 'rachael.ray@gmail.com',
+    status: 'published',
     date: moment(),
   },
   {
     firstName: 'guy',
     lastName: 'fieri',
     email: 'dinersdriveinsandlols@gmail.com',
+    status: 'unpublished',
     avatar: '',
     date: moment(),
   },
@@ -129,7 +152,6 @@ class Wrapper extends Component {
         paginationText={paginationText}
         changeRowsPerPage={this.changeRowsPerPage}
         nextPage={nextPage}
-        listRowOnclick={listRowOnclick}
         previousPage={previousPage}
         handleDelete={handleDelete}
         actions={actions}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mui-table",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "A react component that takes data & style parameters, and renders a Material UI table.",
   "main": "dist/components/list/index.js",
   "scripts": {

--- a/src/components/list/ListAction.js
+++ b/src/components/list/ListAction.js
@@ -10,16 +10,23 @@ const styles = {
   maxHeight: 16,
 };
 
-// TODO: figure out how to handle conditional icons for MenuItem leftIcon option
-const ListAction = ({ actions, avatar }) =>
+const ListAction = ({ actions, avatar, item }) =>
   <IconMenu
     style={{ ...styles, top: avatar ? -2 : -10 }}
     iconButtonElement={<IconButton><MoreVertIcon /></IconButton>}>
-    {actions.map((action, i) =>
-      <MenuItem
-        key={i}
-        primaryText={action.text} />
-    )}
+    {actions.map((action, i) => {
+      const enabled = typeof action.enabled === 'function' ? action.enabled(item) : action.enabled;
+
+      if (enabled) {
+        return (
+          <MenuItem
+            key={i}
+            leftIcon={action.icon}
+            onClick={action.handler}
+            primaryText={action.text} />
+        );
+      }
+    })}
   </IconMenu>;
 
 export default ListAction;

--- a/src/components/list/ListRow.js
+++ b/src/components/list/ListRow.js
@@ -20,11 +20,6 @@ export default class ListRow extends Component {
     this.setState({ hoverState: !this.state.hoverState });
   }
 
-  rowClickHandler = () => {
-    const { item, listRowOnclick } = this.props;
-    listRowOnclick(item);
-  }
-
   render() {
     const rowColumns = [];
     const { item, actions, columns, avatar, deepFind, itemsSelected } = this.props;
@@ -91,7 +86,6 @@ export default class ListRow extends Component {
       // TODO: optimize
       <ListItem
         style={{ ...styles.row, ...hoverStateStyle }}
-        onClick={this.rowClickHandler}
         onMouseEnter={this.toggleHoverState}
         onMouseLeave={this.toggleHoverState}>
         <Checkbox
@@ -100,6 +94,7 @@ export default class ListRow extends Component {
           checked={Boolean(deepFind(item, itemsSelected))} />
         {rowColumns}
         <ListAction
+          item={item}
           avatar={avatar}
           actions={actions} />
       </ListItem>

--- a/src/components/list/index.js
+++ b/src/components/list/index.js
@@ -87,7 +87,7 @@ export default class ReactMuiTable extends Component {
           handleSearch={this.props.handleSearch} />
       );
     }
-    
+
     return (
       <div className={this.props.containerClass} style={this.props.containerStyle}>
         <MuiThemeProvider>
@@ -114,7 +114,6 @@ export default class ReactMuiTable extends Component {
                     key={i}
                     checkRow={this.checkRow}
                     uncheckRow={this.uncheckRow}
-                    listRowOnclick={this.props.listRowOnclick}
                     columns={this.props.columns}
                     item={item}
                     deepFind={deepFind}


### PR DESCRIPTION
So, adding an onClick event for the ListRow apparently will override the onClick event for the 'more' action menu on the far right.  I removed the ListRow onClick, and added in the actions for the 'more' menu dropdown for each row, and also dropdown icons.  Right now, we will only support the following 4 icons: delete, edit, publish, unpublish.