### PR TITLE
Bug fix: menu click routing and delete handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mui-table",
-  "version": "0.0.21",
+  "version": "0.0.24",
   "description": "A react component that takes data & style parameters, and renders a Material UI table.",
   "main": "dist/MaterialTable.js",
   "scripts": {

--- a/src/ActionBar/index.js
+++ b/src/ActionBar/index.js
@@ -3,12 +3,12 @@ import React from 'react';
 import Delete from './Delete';
 import Filter from './Filter';
 
-const ActionBar = ({ itemSelectedCount, handleDeletePointer, filters, handleFilter }) => {
+const ActionBar = ({ itemSelectedCount, handleDelete, filters, handleFilter }) => {
   if (itemSelectedCount) {
     return (
       <Delete
         itemSelectedCount={itemSelectedCount}
-        handleDeletePointer={handleDeletePointer} />
+        handleDelete={handleDelete} />
     );
   }
   if (filters.length === 0) return null;

--- a/src/ActionMenu/ActionMenu.js
+++ b/src/ActionMenu/ActionMenu.js
@@ -23,7 +23,7 @@ class ActionMenu extends Component {
         onClick={this.stopPropagation}
         iconButtonElement={<IconButton><MoreVertIcon color={lightBlack} /></IconButton>}>
         {actions.map((action) => {
-          let enabled = action.enabled || true;
+          let enabled = typeof action.enabled === 'boolean' ? action.enabled : true;
           if (typeof action.enabled === 'function') enabled = action.enabled(item);
           if (!enabled) return null;
           return (

--- a/src/MaterialTable.js
+++ b/src/MaterialTable.js
@@ -73,6 +73,8 @@ export default class MaterialTable extends Component {
   handleRowClick = (rowId, colId) => {
     if (!this.props.onItemClick) return null; // Do nothing if no click handler
     if (colId < 0) return null; // Do nothing if clicking the checkbox
+    const actionCol = this.props.columns.length + (this.props.avatar ? 1 : 0);
+    if (colId === actionCol) return null;
     const { itemsSelected } = this.state;
     if (itemsSelected.length > 0 && !itemsSelected.includes(rowId)) {
       // Do nothing after having selected other items and clicking a row
@@ -174,7 +176,9 @@ export default class MaterialTable extends Component {
                   {this.props.columns.map((column) => {
                     if (!this.displayColumn(column)) return null;
                     let columnValue = selectn(column.key, item);
-                    if (columnValue && column.format) columnValue = column.format(columnValue);
+                    if (columnValue !== undefined && column.format) {
+                      columnValue = column.format(columnValue);
+                    }
                     return (
                       <TableRowColumn key={column.label} colSpan={column.colSpan}>
                         {columnValue || ''}


### PR DESCRIPTION
exits row selection function early if clicking the action column
fixes the passing of handleDelete prop.
Resolve #23 
Resolve #24

Signed-off-by: brad-decker <bhdecker84@gmail.com>