### PR TITLE
[TableBodyRow]: Fix bug where format function ignored falsy values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mui-table",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "A react component that takes data & style parameters, and renders a Material UI table.",
   "main": "dist/MaterialTable.js",
   "scripts": {

--- a/src/components/TableBodyRow/TableBodyRow.js
+++ b/src/components/TableBodyRow/TableBodyRow.js
@@ -45,7 +45,7 @@ const TableBodyRow = (props: TableBodyRowProps) => {
       {columns.map((column) => {
         if (!displayColumn(column)) return null;
         let columnValue = selectn(column.key, item);
-        if (columnValue && column.format) {
+        if (column.format) {
           columnValue = column.format(columnValue, item);
         }
         return (


### PR DESCRIPTION
I inadvertently introduced this bug in #26. 

The previous solution was to ensure that `columnValue` was not `undefined` before using the format function. Personally, I think that we should allow `undefined` to be formatted as well.

I released the checkbox fix prior to merging #30 so this release will include all of that work as well.