### PR TITLE
Write docs & Refine Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,205 @@
+### React MUI Table
+
+A configurable Table component for displaying data sets using Material Design.
+
+This package won't manage data, it only displays it. Callbacks are provided to trigger page changes, filter activation, searches, etc.
+
+The `items` prop is where all of data gets passed in. All other props are for configuring table options. The table should work for any data set provided that the data is an array of objects.
+
+**Install**
+```bash
+$ yarn install react-mui-table
+```
+
+**Import**
+```js
+import MaterialTable from 'react-mui-table';
+```
+
+### Props
+
+Some of the prop types are complex enough that I have documented their Flowtypes instead of creating a table or writing them out. If you aren't familiar with Flow, here are a couple key points.
+* A `?` denotes an optional parameter/property.
+* `void` represents `undefined`.
+* `Array<MyType>` denotes an array that contains only values that conform to type `MyType`
+* `*` allows any type
+
+**items**
+
+  * description: Item can be an object of any shape. Most of the configuration to display the data in the table will be done in the columns prop.
+  * type: `Array<Object>`
+
+
+**itemUniqueId**
+
+  * description:  Path to access a unique value within the current item. Used for React keys. (Ex: "item.author.id")
+  * type: `string`
+
+
+**columns**
+
+  * description: Array of ColumnConfig objects. This how options like sortable, column label, and display override are set.
+  * type: `Array<ColumnConfig>` where `ColumnConfig` is an Object with the following shape:
+```
+type ColumnConfig = {
+  // Label to display at the top of the column
+  label: string,
+
+  // If the column should be clickable for sorting
+  sortable?: boolean,
+
+  // Override the visual representation of the column's data
+  format?: (
+    columnDataItem: any,
+    columnDataObject: Object
+  ) => React$Element<*> | string,
+
+  // Path to access the value within the current item (Ex: "item.author.firstName")
+  key: string,
+
+  // Number of columns wide this column should be.
+  // Useful for giving long values more room in the table.
+  // Note: this doens't map to a grid system but rather simply
+  // passes the 'colspan' html prop down to the underlying column
+  // http://www.w3schools.com/TagS/att_td_colspan.asp
+  colSpan?: number,
+
+  // Should this column display on extra small screens? Default: true
+  xs?: boolean,
+
+  // Should this column display on small screens? Default: true
+  sm?: boolean,
+
+  // Should this column display on medium screens? Default: true
+  md?: boolean,
+
+  // Should this column display on large screens? Default: true
+  lg?: boolean,
+
+  // Should this column display on extra large screens? Default: true
+  xl?: boolean,
+
+  // Tooltip description for this column
+  tooltip?: string,
+}
+```
+
+**filters (Optional)**
+
+  * description: Define the name and presets for each set of filters.
+  * type: `Array<FilerConfig>` where `FilerConfig` is an Object with the following shape:
+
+```
+type FilterConfig = {
+  // Label will be used as the "Title" for this set of filters
+  label: string,
+
+  // Unique identifier for each set of filters. It will be passed into the callback as a way to identify which filters have changed.
+  key: string,
+
+  // An array of possible values to filter by. A checkbox will be rendered for each option.
+  options: Array<string>,
+}
+```
+
+**actions (Optional)**
+
+  * description: Define the presentation, handlers, and visibility for each action.
+  * type: `Array<ActionConfig>` where `ActionConfig` is an Object with the following shape:
+
+```
+type ActionConfig = {
+  // The label of the action in the dropdown menu
+  text: string,
+
+  // The callback to be fired when the action is clicked
+  handler: ActionHandler,
+
+  // Should this action be enabled. boolean or function that returns boolean
+  enabled: boolean|(target: Object) => boolean,
+
+  // Icon to use in the menu for the action
+  icon: React$Element<*>,
+}
+```
+
+**currentSort (Optional)**
+
+  * description: Manipulate the UI to match the sort state in your application.
+  * type: Object with the following shape:
+```
+type currentSort = {
+  // Direction that the column is sorted
+  direction: 'ASC' | 'DESC',
+
+  // Corresponds to the label of the column that is sorted.
+  label: string,
+}
+```
+
+### Prop Groups
+
+The following sections consist of top level props that are documented in groups based on their purpose.
+
+**Pagination (Optional)**
+
+These props determine how pagination should work in the table.
+```
+hasNextPage?: boolean,
+hasPreviousPage?: boolean,
+
+// Ex: "1-4 of 10,000"
+paginationText?: string,
+
+// When invoked, should pass in the new set of items with updated pagination data.
+previousPage?: (...args: Array<void>) => void,
+
+// When invoked, should pass in the new set of items with updated pagination data.
+nextPage?: (...args: Array<void>) => void,
+// Number of rows on the table
+rows?: number,
+
+// If the table should allow the user to switch the number of rows, specify which options they should have
+rowOptions?: Array<number>,
+
+// When invoked, should pass in the new set of items with updated pagination data.
+changeRowsPerPage?: (newRowCount: number) => void,
+```
+
+**Handler Props**
+
+Callback functions that will be invoked when certain interactions occur. These functions will need to update the `items` array passed in if the displayed items should be reordered or updated.
+```
+// label: Corresponds to column label.
+// key: `column.key` for column that is being sorted.
+// direction: 'ASC', 'DESC', or null
+handleSort?: (label?: string, direction?: string, key?: string) => void,
+
+// itemsToDelete: All items that had a checked state when the delete button was clicked.
+handleDelete?: (itemsToDelete: Array<Object>) => void,
+
+// key: The unique identifier for this filter (filters[x].key)
+// activeOptions: An array containing all of this filter's options (filters[x].options)that are currently active.
+handleFilter?: (key: string, activeOptions: Array<string|void>) => void,
+
+// query: string that is currently typed into the search bar.
+handleSearch?: (query: string) => void,
+
+// item: corresponds to the row being clicked.
+onItemClick?: (item: Object) => void,
+```
+
+
+**Visual Options**
+
+```
+// Inline style object to style the top level component.
+containerStyle?: Object,
+
+// Used in the Search bar's placeholder text
+tableName?: string,
+
+// Used to display an avatar on the left side of the row.
+// Must be a path to access an image source within an item, or a function that will return the image source.
+avatar?: string | (item: Object) => string|void,
+```

--- a/flow/common-types.js
+++ b/flow/common-types.js
@@ -6,6 +6,8 @@ export type ActionHandler = (target: Object) => {};
 export type ChangeRowsPerPage = (newRowCount: number) => void;
 export type NextPage = NoArgsNoReturn;
 export type PreviousPage = NoArgsNoReturn;
+type GetImageSrc = (item: Object) => string|void;
+export type Avatar = GetImageSrc|string;
 
 // Passed nothing to clear the sort, otherwise all are required
 export type HandleSort = (label?: string, direction?: string, key?: string) => void;
@@ -16,7 +18,7 @@ export type FormatFunction = (
 ) => React$Element<*> | string;
 
 export type CurrentSort = {
-  direction: string,
+  direction: 'ASC' | 'DESC',
   label: string,
 }
 

--- a/src/components/ActionBar/types.js
+++ b/src/components/ActionBar/types.js
@@ -5,7 +5,7 @@ export type ActionBarProps = {
   itemSelectedCount: number,
   deleteEnabled: boolean,
   handleDelete: Function,
-  filters: Array<Object>,
+  filters: Array<FilterConfig>,
   handleFilter: Function,
   filterEnabled: boolean,
 }

--- a/src/components/MaterialTable/MaterialTable.js
+++ b/src/components/MaterialTable/MaterialTable.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import isEqual from 'lodash.isequal';
 import respondable from 'respondable';
 import Paper from 'material-ui/Paper';
+import selectn from 'selectn';
 
 import {
   Table,
@@ -49,6 +50,11 @@ const breakpointObject = {
 const priorities = ['xs', 'sm', 'md', 'lg', 'xl'];
 
 export default class MaterialTable extends Component {
+
+  static defaultProps = {
+    rows: 30,
+  }
+
   props: MaterialTableProps
   state: MaterialTableState = {
     selections: this.props.items.map(() => false),
@@ -254,7 +260,7 @@ export default class MaterialTable extends Component {
             <TableBody showRowHover style={styles.tableBody} displayRowCheckbox={false}>
               {items.map((item, tableIdx) => (
                 <TableBodyRow
-                  key={item[itemUniqueId]}
+                  key={selectn(itemUniqueId, item)}
                   actions={actions}
                   item={item}
                   itemUniqueId={itemUniqueId}

--- a/src/components/MaterialTable/types.js
+++ b/src/components/MaterialTable/types.js
@@ -3,14 +3,13 @@ import type {
   ActionConfig,
   ColumnConfig,
   FilterConfig,
-
   PreviousPage,
   NextPage,
   ChangeRowsPerPage,
-
   HandleFilter,
   HandleSort,
   CurrentSort,
+  Avatar,
 } from '../../../flow/common-types';
 
 export type MaterialTableState = {
@@ -24,7 +23,7 @@ export type MaterialTableProps = {
   items: Array<Object>,
   itemUniqueId: string,
   filters?: Array<FilterConfig>,
-  avatar?: string,
+  avatar?: Avatar,
   actions?: Array<ActionConfig>,
   columns: Array<ColumnConfig>,
   onItemClick?: (item: Object) => void,
@@ -35,12 +34,12 @@ export type MaterialTableProps = {
   previousPage?: PreviousPage,
   nextPage?: NextPage,
 
-  rows: number,
+  rows?: number,
   rowOptions?: Array<number>,
   changeRowsPerPage?: ChangeRowsPerPage,
   currentSort?: CurrentSort,
   handleSort?: HandleSort,
-  handleDelete?: (itemToDelete: Array<Object>) => void,
+  handleDelete?: (itemsToDelete: Array<Object>) => void,
   handleFilter?: HandleFilter,
   handleSearch?: (query: string) => void,
 

--- a/src/components/Pagination/RowsPerPage.js
+++ b/src/components/Pagination/RowsPerPage.js
@@ -28,16 +28,17 @@ class RowsPerPage extends Component {
   }
 
   render() {
+    const { changeRowsPerPage, paginationText, rows } = this.props;
     return (
       <div style={rowsPerPageStyles.rowsPerPage}>
-        {this.props.changeRowsPerPage && (
+        {changeRowsPerPage && (
           <span style={rowsPerPageStyles.rowsText}>
             Rows per page:
           </span>
         )}
-        {this.props.changeRowsPerPage && (
+        {changeRowsPerPage && (
           <DropDownMenu
-            value={this.props.rows}
+            value={rows}
             style={rowsPerPageStyles.dropDownMenu}
             labelStyle={rowsPerPageStyles.dropDownMenu}
             onChange={this.menuChangeHandler}
@@ -50,7 +51,7 @@ class RowsPerPage extends Component {
               )}
           </DropDownMenu>
         )}
-        <span>{this.props.paginationText}</span>
+        <span>{paginationText}</span>
       </div>
     );
   }

--- a/src/components/SortableTableHeaderColumn/SortableTableHeaderColumn.js
+++ b/src/components/SortableTableHeaderColumn/SortableTableHeaderColumn.js
@@ -32,7 +32,7 @@ export default class MaterialHeaderColumn extends Component {
   isCurrentSort: IsCurrentSort = () => this.props.currentSort.label === this.props.label;
 
   // Shortcut for a often used boolean check
-  isSortable: IsSortable = () => this.props.sortable;
+  isSortable: IsSortable = () => this.props.sortable === true;
 
   /**
    * Generates a style object for the current column

--- a/src/components/SortableTableHeaderColumn/types.js
+++ b/src/components/SortableTableHeaderColumn/types.js
@@ -11,7 +11,7 @@ export type MaterialHeaderColumnProps = {
 
   // spread column properties
   label: string,
-  sortable: boolean,
+  sortable?: boolean,
   format?: FormatFunction,
   colSpan?: number,
   xs?: boolean,

--- a/src/components/TableBodyRow/TableBodyRow.js
+++ b/src/components/TableBodyRow/TableBodyRow.js
@@ -68,7 +68,7 @@ const TableBodyRow = (props: TableBodyRowProps) => {
           <ActionMenu
             actions={actions}
             item={item}
-            itemId={item[itemUniqueId]} />
+            itemId={selectn(itemUniqueId, item)} />
         </TableRowColumn>
       )}
     </TableRow>

--- a/src/components/TableBodyRow/types.js
+++ b/src/components/TableBodyRow/types.js
@@ -2,6 +2,7 @@
 import type {
   ColumnConfig,
   ActionConfig,
+  Avatar,
 } from '../../../flow/common-types';
 import type {
   HandleSelect,
@@ -14,7 +15,7 @@ export type TableBodyRowProps = {
   item: Object,
   itemUniqueId: string,
   tableIdx: number,
-  avatar: string,
+  avatar: Avatar,
   columns: Array<ColumnConfig>,
   displayColumn: DisplayColumn,
   displayAvatar: DisplayAvatar,
@@ -23,5 +24,4 @@ export type TableBodyRowProps = {
   actionsEnabled: boolean,
 };
 
-type GetImageSrc = (item: Object) => string|void;
-export type GetAvatarSrc = (avatar: GetImageSrc|string, item: Object) => string|void;
+export type GetAvatarSrc = (avatar: Avatar, item: Object) => string|void;

--- a/src/components/TableHeaderRow/types.js
+++ b/src/components/TableHeaderRow/types.js
@@ -4,6 +4,7 @@ import type {
   ColumnConfig,
   HandleSort,
   CurrentSort,
+  Avatar,
 } from '../../../flow/common-types';
 import type {
   DisplayAvatar,
@@ -15,7 +16,7 @@ export type TableHeaderRowProps = {
 
   handleSort: HandleSort,
   currentSort: CurrentSort,
-  avatar: string,
+  avatar: Avatar,
   columns: Array<ColumnConfig>,
 
   handleSelectAll: NoArgsNoReturn,


### PR DESCRIPTION
Resolves #31 

These docs aren't perfect, but I think they cover most of the essentials. This is intended to be a good first iteration 👍 

I'm sure I've been looking at this too long to notice some issues, please let me know if there are any changes that would make this information easier to digest.

Changes:
* Add README.md
* `rows` (top level prop) is optional now. (All of the other pagination props are optional as well)
* `columns.sortable` is now optional as well
* Removed some generic types
* Updated avatar's type to allow either a function or string.